### PR TITLE
Add more options to parameterize the model

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,33 @@ definitions:
         description: Unique Identifier representing a document
         x-primary-key: true
 ```
+
+## Additional parametrization
+
+In the same way as with `x-primary-key`, you can parameterize the attributes `x-autoincrement`, `x-unique` and `x-allow-null`
+
+## Default value for UUID fields
+
+It is possible to set default values for fields with `uuid` format
+##### JSON
+```JSON
+"definitions": {
+    "Document": {
+        "properties": {
+            "id": {
+                "type": "string",
+                "format": "uuid",
+                "default": "Sequelize.UUIDV4"
+            },
+```
+##### YAML
+```YAML
+definitions:
+  # Model definition
+  Document:
+    properties:
+      id:
+        type: string
+        format: uuid
+        default: Sequelize.UUIDV4
+```

--- a/index.js
+++ b/index.js
@@ -184,16 +184,26 @@ function generate(schema) {
   Object.keys(result).forEach(propertyName => {
     var propertySchema = result[propertyName];
 
-    // BEGIN: Promote Attribute to primaryKey with autoIncrement
-    if (propertySchema["x-primary-key"] === true) {
+    if (propertySchema["x-primary-key"]) {
       propertySchema.primaryKey = true;
+    }
+    if (propertySchema["x-autoincrement"]) {
       propertySchema.autoIncrement = true;
     }
-    // END: Promote Attribute to primaryKey with autoIncrement
+    if (propertySchema["x-unique"]) {
+      propertySchema.unique = propertySchema["x-unique"];
+    }
+    if (propertySchema["x-allow-null"] !== undefined) {
+      propertySchema.allowNull = propertySchema["x-allow-null"];
+    }
 
     propertySchema.type = getSequalizeType(propertySchema);
     if (propertySchema.default !== undefined) {
-      propertySchema.defaultValue = propertySchema.default;
+      if (propertySchema.format === "uuid") {
+        propertySchema.defaultValue = eval(propertySchema.default);
+      } else {
+        propertySchema.defaultValue = propertySchema.default;
+      }
     }
   });
 


### PR DESCRIPTION
- Parameterize independently _primary-key_ and _autoincrement_
- Possibility to parameterize _unique_ and _allow null_ fields 
- Possibility of setting default value to fields with _uuid_ format